### PR TITLE
Add support for direct IP or hostname

### DIFF
--- a/keylights
+++ b/keylights
@@ -22,7 +22,11 @@
 # Depends on: avahi-resolve, curl, awk, jq
 
 resolve_hostname() {
-    KL_IP=$(avahi-resolve -n $KL_HOSTNAME | awk '{print $2}')
+    if [[ $KL_HOSTNAME =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        KL_IP=$KL_HOSTNAME
+    else
+        KL_IP=$(avahi-resolve -n $KL_HOSTNAME | awk '{print $2}')
+    fi
 }
 
 fetch_state() {


### PR DESCRIPTION
Uses a simple regex match to detect if an IP address is directly provided else it falls back to hostname resolution

Currently only support IPv4 as IPv6 detection is quite a bit more difficult

PS thanks for the awesome script :) 