### PR TITLE
Add support for direct ipv4 in place of hostnames + cleanup of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,31 +4,60 @@ Simple bash script to control my Elgato Key Light Air
 
 Depends on: avahi-resolve, curl, awk, jq
 
-## Usage:
+## Usage
 
 `./keylights -h <hostname> <action>`
 
 ### Examples
 
 #### Turn light on/off
-```
+
+Using hostname resolution:
+
+```bash
 ./keylights -h=elgato-key-light-air-12ab.local on
 ./keylights -h=elgato-key-light-air-12ab.local off
 ./keylights -h=elgato-key-light-air-12ab.local toggle
 ```
 
+Using IP address:
+
+```bash
+./keylights -h=192.168.0.10 on
+./keylights -h=192.168.0.10 off
+./keylights -h=192.168.0.10 toggle
+```
+
 #### Turn brightness up/down
 
-```
+Using hostname resolution:
+
+```bash
 ./keylights -h=elgato-key-light-air-12ab.local b+
 ./keylights -h=elgato-key-light-air-12ab.local b-
 ```
 
+Using IP address:
+
+```bash
+./keylights -h=192.168.0.10 b+
+./keylights -h=192.168.0.10 b-
+```
+
 #### Turn temperature up/down
 
-```
+Using hostname resolution:
+
+```bash
 ./keylights -h=elgato-key-light-air-12ab.local t+
 ./keylights -h=elgato-key-light-air-12ab.local t-
+```
+
+Using IP address:
+
+```bash
+./keylights -h=192.168.0.10 t+
+./keylights -h=192.168.0.10 t-
 ```
 
 ### Hint

--- a/keylights
+++ b/keylights
@@ -22,7 +22,11 @@
 # Depends on: avahi-resolve, curl, awk, jq
 
 resolve_hostname() {
-    KL_IP=$(avahi-resolve -n $KL_HOSTNAME | awk '{print $2}')
+    if [[ $KL_HOSTNAME =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        KL_IP=$KL_HOSTNAME
+    else
+        KL_IP=$(avahi-resolve -n $KL_HOSTNAME | awk '{print $2}')
+    fi
 }
 
 fetch_state() {


### PR DESCRIPTION
Added:

- Support for IPv4 using simple regex matching
- Updated Readme to show examples for hostname vs ipv4

Fixed:

- Fixed code blocks to use bash syntax highlighting

PS Thanks for the awesome script!
